### PR TITLE
[BREAKING] Harden types on ABI objects

### DIFF
--- a/src/abis/abiERC1155.ts
+++ b/src/abis/abiERC1155.ts
@@ -322,4 +322,4 @@ export const abiERC1155 = [
     stateMutability: 'view',
     type: 'function',
   },
-];
+] as const;

--- a/src/abis/abiERC20.ts
+++ b/src/abis/abiERC20.ts
@@ -269,4 +269,4 @@ export const abiERC20 = [
     name: 'Approval',
     type: 'event',
   },
-];
+] as const;

--- a/src/abis/abiERC721.ts
+++ b/src/abis/abiERC721.ts
@@ -373,4 +373,4 @@ export const abiERC721 = [
     name: 'ApprovalForAll',
     type: 'event',
   },
-];
+] as const;


### PR DESCRIPTION
By adding `as const` to the ABI objects, we can ensure that any
functions that take these ABI objects must take them exactly. Without
`as const`, we can only ensure that the input matches a certain shape.
Consequently, this makes this change breaking.

--- 

Fixes #5.