### PR TITLE
Adds `abiFiatTokenV2` to the index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { abiERC20 } from './abis/abiERC20';
 import { abiERC721 } from './abis/abiERC721';
 import { abiERC1155 } from './abis/abiERC1155';
+import { abiFiatTokenV2 } from './abis/fiatTokenV2';
 
-export { abiERC20, abiERC721, abiERC1155 };
+export { abiERC20, abiERC721, abiERC1155, abiFiatTokenV2 };


### PR DESCRIPTION
I forgot to add `abiFiatTokenV2` to the index on https://github.com/MetaMask/metamask-eth-abis/pull/20.