### PR TITLE
Extract build-specific TypeScript configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:clean": "rimraf dist && yarn build",
-    "build": "tsc --project ."
+    "build": "tsc --project tsconfig.build.json"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "inlineSources": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": [
+    "./src/**/__fixtures__/**/*",
+    "./src/**/__mocks__/**/*",
+    "./src/**/__test__/**/*",
+    "./src/**/__tests__/**/*",
+    "./src/**/__snapshots__/**/*",
+    "./src/**/*.test.ts",
+    "./src/**/*.test-d.ts",
+    "./src/**/*.test.*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,12 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
-    "inlineSources": true,
     "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
+    "noEmit": true,
     "strict": true,
     "target": "ES2017"
   },
-  "exclude": ["./src/**/*.test.ts"],
-  "include": ["./src/**/*.ts"]
+  "exclude": ["./dist", "**/node_modules"]
 }


### PR DESCRIPTION
This is a requirement for bumping ESLint packages, since `@metamask/eslint-config-typescript` now enables type-aware rules. Unfortunately, the current TypeScript config file excludes test files, so running `yarn lint` would produce an error once those packages were upgraded.

`tsconfig.build.json` should match the same file in the module template. It is _not_ expected that `tsconfig.json` matches the module template (those will be addressed in another PR).